### PR TITLE
Update target_path parameter name

### DIFF
--- a/Checkout/Step/SecurityStep.php
+++ b/Checkout/Step/SecurityStep.php
@@ -77,7 +77,8 @@ class SecurityStep extends CheckoutStep
     private function overrideSecurityTargetPath()
     {
         $url = $this->generateUrl('sylius_checkout_start', array(), true);
+        $providerKey = $this->container->getParameter('fos_user.firewall_name');
 
-        $this->get('session')->set('_security.main.target_path', $url);
+        $this->get('session')->set('_security.'.$providerKey.'.target_path', $url);
     }
 }


### PR DESCRIPTION
I don't know since when, but Symfony separated the target_path parameter for each firewall.
