### PR TITLE
Update LoadOrdersData.php

### DIFF
--- a/DataFixtures/ORM/LoadOrdersData.php
+++ b/DataFixtures/ORM/LoadOrdersData.php
@@ -43,7 +43,7 @@ class LoadOrdersData extends DataFixture
             $order->setUser($this->getReference('Sylius.User-'.rand(1, 15)));
             $order->setShippingAddress($this->createAddress());
             $order->setBillingAddress($this->createAddress());
-            $order->setCreatedAt($this->faker->dateTimeBetween('1 year ago', 'now'));
+            $order->setCreatedAt(new \DateTime(sprintf("-%d day", $i)));
 
             $order->calculateTotal();
 


### PR DESCRIPTION
There is an error in the fixtures, the date creation of the orders can't be generated at random because the OrderNumberGenerator generate the number based on the last creation order.
